### PR TITLE
Force local player to rest pose on export

### DIFF
--- a/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
+++ b/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
@@ -204,8 +204,14 @@ public class ModelDumperPlugin extends Plugin
 
 	private void exportLocalPlayerModel() throws IOException
 	{
+		Player localPlayer = client.getLocalPlayer();
+		if (config.forceRestPose())
+		{
+			localPlayer.setAnimation(2566);
+			localPlayer.setActionFrame(0);
+		}
 		DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
-		export(client.getLocalPlayer().getModel(), "Player " + client.getLocalPlayer().getName() + " " + TIME_FORMAT.format(new Date()) + ".obj");
+		export(localPlayer.getModel(), "Player " + client.getLocalPlayer().getName() + " " + TIME_FORMAT.format(new Date()) + ".obj");
 	}
 
 	private void exportObjectModel(String menuTarget, int id) throws IOException

--- a/src/main/java/net/bram91/modeldumper/ModelDumperPluginConfig.java
+++ b/src/main/java/net/bram91/modeldumper/ModelDumperPluginConfig.java
@@ -43,7 +43,7 @@ public interface ModelDumperPluginConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "material",
+			keyName = "forceRestPose",
 			name = "Force Rest Pose (Local Player)",
 			description = "Forces local player to perform an animation on export. The resulting model is in a rest pose.",
 			position = 2

--- a/src/main/java/net/bram91/modeldumper/ModelDumperPluginConfig.java
+++ b/src/main/java/net/bram91/modeldumper/ModelDumperPluginConfig.java
@@ -41,4 +41,12 @@ public interface ModelDumperPluginConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+			keyName = "material",
+			name = "Force Rest Pose (Local Player)",
+			description = "Forces local player to perform an animation on export. The resulting model is in a rest pose.",
+			position = 2
+	)
+	default boolean forceRestPose() { return false; }
 }


### PR DESCRIPTION
Adds a config option to force the local player into a rest pose. When enabled, the exported local player model will be in a simple, symmetrical pose. This is useful for the purposes of 3D rigging and animation.

![rest_pose](https://user-images.githubusercontent.com/46876568/117539507-e7c80280-b002-11eb-880a-d752d624203f.png)
