### PR TITLE
Make it possible to export ground item models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 nbactions.xml
 nb-configuration.xml
 nbproject/
+bin/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Model Exporter
-Allows exporting player/npc/object models by shift + right clicking them and selecting the `Export Model` option.
+
+Allows exporting player/npc/object models and ground items by shift + right clicking them and selecting the `Export Model` option.
 To export the local player right click the equipment tab(If you use resizable mode with the side panel option enabled it will be on right click inventory).
 
-##### Colors can be exported with the exception of firecape/infernal cape textures #####
-
+##### Colors can be exported with the exception of firecape/infernal cape textures
 
 Models will be stored in the `.runelite/models/` folder.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.1'
+def runeLiteVersion = '1.7.19-SNAPSHOT'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/net/bram91/modeldumper/GroundItem.java
+++ b/src/main/java/net/bram91/modeldumper/GroundItem.java
@@ -2,7 +2,6 @@ package net.bram91.modeldumper;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 import net.runelite.api.Model;
 import net.runelite.api.TileItem;
 import net.runelite.api.coords.WorldPoint;
@@ -10,9 +9,7 @@ import net.runelite.api.coords.WorldPoint;
 @Data
 @Builder
 class GroundItem {
-    @Getter
     private int id;
-    
     private TileItem item;
     private WorldPoint location;
     private int quantity;

--- a/src/main/java/net/bram91/modeldumper/GroundItem.java
+++ b/src/main/java/net/bram91/modeldumper/GroundItem.java
@@ -1,0 +1,23 @@
+package net.bram91.modeldumper;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import net.runelite.api.Model;
+import net.runelite.api.TileItem;
+import net.runelite.api.coords.WorldPoint;
+
+@Data
+@Builder
+class GroundItem {
+    @Getter
+    private int id;
+    
+    private TileItem item;
+    private WorldPoint location;
+    private int quantity;
+
+    public Model getModel() {
+        return this.item.getModel();
+    }
+}

--- a/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
+++ b/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 import com.google.inject.Provides;
 
-import lombok.Getter;
 import java.awt.Color;
 import java.awt.Shape;
 import java.io.File;
@@ -106,7 +105,6 @@ public class ModelDumperPlugin extends Plugin
 		return configManager.getConfig(ModelDumperPluginConfig.class);
 	}
 
-	@Getter
 	private final Table<WorldPoint, Integer, GroundItem> groundItems = HashBasedTable.create();
 
 	@Override

--- a/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
+++ b/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
@@ -393,6 +393,7 @@ public class ModelDumperPlugin extends Plugin
 			.id(item.getId())
 			.item(item)
 			.location(tile.getWorldLocation())
+			.quantity(item.getQuantity())
 			.build();
 
 		GroundItem existing = groundItems.get(tile.getWorldLocation(), item.getId());

--- a/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
+++ b/src/main/java/net/bram91/modeldumper/ModelDumperPlugin.java
@@ -25,8 +25,12 @@
  */
 package net.bram91.modeldumper;
 
+import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Table;
 import com.google.inject.Provides;
+
+import lombok.Getter;
 import java.awt.Color;
 import java.awt.Shape;
 import java.io.File;
@@ -35,7 +39,9 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,7 +49,12 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import net.runelite.api.*;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ClientTick;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.ItemDespawned;
+import net.runelite.api.events.ItemQuantityChanged;
+import net.runelite.api.events.ItemSpawned;
 import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NpcSpawned;
@@ -95,6 +106,9 @@ public class ModelDumperPlugin extends Plugin
 		return configManager.getConfig(ModelDumperPluginConfig.class);
 	}
 
+	@Getter
+	private final Table<WorldPoint, Integer, GroundItem> groundItems = HashBasedTable.create();
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -109,6 +123,7 @@ public class ModelDumperPlugin extends Plugin
 		menuManager.removeManagedCustomMenu(FIXED_EQUIPMENT_TAB_EXPORT);
 		menuManager.removeManagedCustomMenu(RESIZABLE_EQUIPMENT_TAB_EXPORT);
 		menuManager.removeManagedCustomMenu(RESIZABLE_VIEWPORT_BOTTOM_LINE_INVENTORY_TAB_EXPORT);
+		groundItems.clear();
 	}
 
 	@Subscribe
@@ -121,7 +136,7 @@ public class ModelDumperPlugin extends Plugin
 			MenuEntry target = null;
 			for (MenuEntry menuEntry : menuEntries)
 			{
-				if (menuEntry.getOption().toLowerCase().equals("drop") || menuEntry.getOption().toLowerCase().equals("destroy") || menuEntry.getOption().toLowerCase().equals("take") || menuEntry.getOption().toLowerCase().equals("pick-up"))
+				if (menuEntry.getOption().toLowerCase().equals("drop") || menuEntry.getOption().toLowerCase().equals("destroy"))
 				{
 					return;
 				}
@@ -228,6 +243,8 @@ public class ModelDumperPlugin extends Plugin
 				if (tile != null)
 				{
 					GameObject[] gameObjects = tile.getGameObjects();
+					Collection<GroundItem> groundItemsOnTile = groundItems.row(tile.getWorldLocation()).values();
+
 					for (int i = 0; i < gameObjects.length; i++)
 					{
 						if (gameObjects[i] != null && gameObjects[i].getId() == id)
@@ -237,6 +254,15 @@ public class ModelDumperPlugin extends Plugin
 								DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
 								export((Model) gameObjects[i].getRenderable(), "Object " + Text.removeFormattingTags(menuTarget) + " " + TIME_FORMAT.format(new Date()) + ".obj");
 							}
+						}
+					}
+
+					for (Iterator<GroundItem> iterator = groundItemsOnTile.iterator(); iterator.hasNext();) {
+						GroundItem groundItem = iterator.next();
+
+						if (groundItem.getId() == id) {
+							DateFormat TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+							export((Model) groundItem.getModel(), "Item " + Text.removeFormattingTags(menuTarget) + " " + TIME_FORMAT.format(new Date()) + ".obj");
 						}
 					}
 				}
@@ -346,6 +372,79 @@ public class ModelDumperPlugin extends Plugin
 			materialWriter.write(materialData);
 			materialWriter.flush();
 			materialWriter.close();
+		}
+	}
+
+	@Subscribe
+	public void onGameStateChanged(final GameStateChanged event)
+	{
+		if (event.getGameState() == GameState.LOADING)
+		{
+			groundItems.clear();
+		}
+	}
+
+	// borrowed from official Ground Items plugin
+	@Subscribe
+	public void onItemSpawned(ItemSpawned itemSpawned)
+	{
+		TileItem item = itemSpawned.getItem();
+		Tile tile = itemSpawned.getTile();
+
+		final GroundItem groundItem = GroundItem.builder()
+			.id(item.getId())
+			.item(item)
+			.location(tile.getWorldLocation())
+			.build();
+
+		GroundItem existing = groundItems.get(tile.getWorldLocation(), item.getId());
+		if (existing != null)
+		{
+			existing.setQuantity(existing.getQuantity() + groundItem.getQuantity());
+		}
+		else
+		{
+			groundItems.put(tile.getWorldLocation(), item.getId(), groundItem);
+		}
+	}
+
+	// borrowed from official Ground Items plugin
+	@Subscribe
+	public void onItemDespawned(ItemDespawned itemDespawned)
+	{
+		TileItem item = itemDespawned.getItem();
+		Tile tile = itemDespawned.getTile();
+
+		GroundItem groundItem = groundItems.get(tile.getWorldLocation(), item.getId());
+		if (groundItem == null)
+		{
+			return;
+		}
+
+		if (groundItem.getQuantity() <= item.getQuantity())
+		{
+			groundItems.remove(tile.getWorldLocation(), item.getId());
+		}
+		else
+		{
+			groundItem.setQuantity(groundItem.getQuantity() - item.getQuantity());
+		}
+	}
+
+	// borrowed from official Ground Items plugin
+	@Subscribe
+	public void onItemQuantityChanged(ItemQuantityChanged itemQuantityChanged)
+	{
+		TileItem item = itemQuantityChanged.getItem();
+		Tile tile = itemQuantityChanged.getTile();
+		int oldQuantity = itemQuantityChanged.getOldQuantity();
+		int newQuantity = itemQuantityChanged.getNewQuantity();
+
+		int diff = newQuantity - oldQuantity;
+		GroundItem groundItem = groundItems.get(tile.getWorldLocation(), item.getId());
+		if (groundItem != null)
+		{
+			groundItem.setQuantity(groundItem.getQuantity() + diff);
 		}
 	}
 


### PR DESCRIPTION
I'm pretty rusty with Java and this is also my first time ever touching RuneLite code, so this might not be the best way of doing things.

What I've tested:
- Dropping multiple of the same item in the same spot and picking them up
- Items on tables
- Items that were already present