### PR TITLE
Add flat shading check

### DIFF
--- a/src/main/java/net/bram91/modeldumper/JagexColor.java
+++ b/src/main/java/net/bram91/modeldumper/JagexColor.java
@@ -158,4 +158,14 @@ public final class JagexColor
 			| ((int) (g * 256.0D) << 8)
 			| (int) (b * 256.0D);
 	}
+
+	public static int[] createPalette(double brightness)
+	{
+		int[] colorPalette = new int[65536];
+		for (int i = 0; i < colorPalette.length; i++)
+		{
+			colorPalette[i] = HSLtoRGB((short) i, brightness);
+		}
+		return colorPalette;
+	}
 }

--- a/src/main/java/net/bram91/modeldumper/OBJExporter.java
+++ b/src/main/java/net/bram91/modeldumper/OBJExporter.java
@@ -11,9 +11,12 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static net.bram91.modeldumper.JagexColor.createPalette;
+
 public class OBJExporter
 {
 
+    private final static int[] colorPalette = createPalette(JagexColor.BRIGHTNESS_MIN);
     private final static String PATH = RuneLite.RUNELITE_DIR + "//models//";
 
     public static void export(Renderable r, String name)
@@ -103,11 +106,20 @@ public class OBJExporter
             }
             else
             {
-                // get average color of vertices
-                int c1 = m.getFaceColors1()[fi];
-                int c2 = m.getFaceColors2()[fi];
-                int c3 = m.getFaceColors3()[fi];
-                c = JagexColor.HSLtoRGBAvg(c1, c2, c3);
+                if (m.getFaceColors3()[fi] == -1)
+                {
+                    // face should be shaded flat
+                    int colorIndex = m.getFaceColors1()[fi];
+                    int rgbColor = colorPalette[colorIndex];
+                    c = new Color(rgbColor);
+                } else {
+
+                    // get average color of vertices
+                    int c1 = m.getFaceColors1()[fi];
+                    int c2 = m.getFaceColors2()[fi];
+                    int c3 = m.getFaceColors3()[fi];
+                    c = JagexColor.HSLtoRGBAvg(c1, c2, c3);
+                }
             }
 
             // see if our color already has a mtl

--- a/src/main/java/net/bram91/modeldumper/PLYExporter.java
+++ b/src/main/java/net/bram91/modeldumper/PLYExporter.java
@@ -12,8 +12,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static net.bram91.modeldumper.JagexColor.createPalette;
+
 public class PLYExporter
 {
+
+    private final static int[] colorPalette = createPalette(JagexColor.BRIGHTNESS_MIN);
 
     public static void export(Model m, String name) throws IOException
     {
@@ -36,10 +40,18 @@ public class PLYExporter
             }
             else
             {
-                // get average color of vertices
-                vc1 = new Color(JagexColor.HSLtoRGB((short) m.getFaceColors1()[fi], JagexColor.BRIGHTNESS_MIN));
-                vc2 = new Color(JagexColor.HSLtoRGB((short) m.getFaceColors2()[fi], JagexColor.BRIGHTNESS_MIN));
-                vc3 = new Color(JagexColor.HSLtoRGB((short) m.getFaceColors3()[fi], JagexColor.BRIGHTNESS_MIN));
+                if (m.getFaceColors3()[fi] == -1)
+                {
+                    // face should be shaded flat
+                    int colorIndex = m.getFaceColors1()[fi];
+                    int rgbColor = colorPalette[colorIndex];
+                    vc1 = vc2 = vc3 = new Color(rgbColor);
+                } else {
+                    // get color for each vertex
+                    vc1 = new Color(JagexColor.HSLtoRGB((short) m.getFaceColors1()[fi], JagexColor.BRIGHTNESS_MIN));
+                    vc2 = new Color(JagexColor.HSLtoRGB((short) m.getFaceColors2()[fi], JagexColor.BRIGHTNESS_MIN));
+                    vc3 = new Color(JagexColor.HSLtoRGB((short) m.getFaceColors3()[fi], JagexColor.BRIGHTNESS_MIN));
+                }
             }
 
             int vi1 = m.getFaceIndices1()[fi];


### PR DESCRIPTION
If faces are supposed to be rendered flat, they will now use the correct colour for OBJ/PLY exports.

![image](https://github.com/Bram91/Model-Dumper/assets/46876568/c275c66b-db37-45d7-979c-dc87300a8717)
